### PR TITLE
Change default test port to 8088

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Furthermore, you should run the `utils/preparetestjs.sh` script to prepare testi
 
 After this you can run it using:
 
-    node utils/testsp.js http://<SERVER>:8081 [configuration_dir]
+    node utils/testsp.js http://<SERVER>:8088 [configuration_dir]
 
 where `<SERVER>` refers to the IP address or hostname of your running `irma_api_server`, and where the optional second argument specifies the configuration directory in which the script is to find the JWT keys (if absent, `src/main/resources` is assumed). Make sure you use an address that the IRMA app can also reach (we usually use a local ip address for testing).
 

--- a/ansible/roles/apiserver/defaults/main.yml
+++ b/ansible/roles/apiserver/defaults/main.yml
@@ -3,7 +3,7 @@ server_url: https://github.com/privacybydesign/irma_api_server/releases/download
 conf_path: /etc/irma_api_server
 base_install_path: /opt
 install_path: /opt/irma_api_server
-http_port: 8081
+http_port: 8088
 https_port: 8444
 
 irma_configuration: "https://github.com/privacybydesign/irma-demo-schememanager"

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,6 @@ gretty {
     scanInterval = 10
     inplaceMode = "hard"
     httpsEnabled = true
-    httpPort = 8081
+    httpPort = 8088
     httpsPort = 8444
 }


### PR DESCRIPTION
React Native uses port 8081 by default, resulting in a port conflict.